### PR TITLE
VSCode가 빌드 task를 찾지 못하는 문제 해결

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,13 @@
-# Created by https://www.gitignore.io/api/node,macos,windows
-# Edit at https://www.gitignore.io/?templates=node,macos,windows
+
+# Created by https://www.gitignore.io/api/node,macos,windows,code
+# Edit at https://www.gitignore.io/?templates=node,macos,windows,code
+
+### Code ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
 
 ### macOS ###
 # General
@@ -107,6 +115,9 @@ typings/
 # nuxt.js build output
 .nuxt
 
+# react / gatsby 
+public/
+
 # vuepress build output
 .vuepress/dist
 
@@ -145,4 +156,4 @@ $RECYCLE.BIN/
 # Windows shortcuts
 *.lnk
 
-# End of https://www.gitignore.io/api/node,macos,windows
+# End of https://www.gitignore.io/api/node,macos,windows,code

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Launch",
+            "program": "${workspaceFolder}/dist/main.js",
+            "preLaunchTask": "build",
+            "outFiles": [
+                "${workspaceFolder}/dist/**/*.js"
+            ]
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,17 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558 
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "type": "npm",
+            "script": "build",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "problemMatcher": []
+        }
+    ]
+}


### PR DESCRIPTION
- `.vscode` 디렉토리를 레포에 포함시켰습니다.
- `launch.json`에 명시적으로 `preLaunchTask`를 지정하고
- `tasks.json`에 명시적으로 빌드 작업을 정의했습니다.
- 그 외에 자잘하게 `.gitignore` 파일을 수정해서 `.vscode`가 무시되지 않도록 했습니다.